### PR TITLE
remove nonexistent file from CMakeLists.txt

### DIFF
--- a/interpreter/linux/CMakeLists.txt
+++ b/interpreter/linux/CMakeLists.txt
@@ -24,7 +24,6 @@ set(SOURCES
     ../../source/TuiFunction.cpp
     ../../source/TuiRef.cpp
     ../../source/TuiSha1.cpp
-    ../../source/TuiStringUtils.cpp
 )
 
 set(CMAKE_BINARY_DIR ${CMAKE_SOURCE_DIR}/bin)


### PR DESCRIPTION
Seems the the .cpp version of this file is no longer used or needed in CMakeLists.txt, this should fix #2 