### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ interpreter/linux/tui
 interpreter/windows/tui/tui
 interpreter/windows/tui/x64
 examples/examples
+.build

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ interpreter/windows/tui/tui
 interpreter/windows/tui/x64
 examples/examples
 .build
+DerivedData
+.swiftpm
+.vscode

--- a/Package.swift
+++ b/Package.swift
@@ -7,9 +7,9 @@ let package = Package(
     name: "tui",
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
-        // .library(
-        //     name: "tui",
-        //     targets: ["tui"]),
+        .library(
+            name: "tui",
+            targets: ["tui"]),
         .executable(name: "tui-interpreter", targets: ["tui-interpreter"])
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,34 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "tui",
+    products: [
+        // Products define the executables and libraries a package produces, making them visible to other packages.
+        // .library(
+        //     name: "tui",
+        //     targets: ["tui"]),
+        .executable(name: "tui-interpreter", targets: ["tui-interpreter"])
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package, defining a module or a test suite.
+        // Targets can depend on other targets in this package and products from dependencies.
+        .target(
+            name: "tui",
+            path: "source"
+        ),
+        .target(
+            name: "glm",
+            path: "thirdParty/glm",
+            publicHeadersPath: "thirdParty/glm"
+        ),
+        .executableTarget(
+            name: "tui-interpreter",
+            dependencies: ["glm"],
+            path: "interpreter/macos/tui"
+        )
+    ],
+    cxxLanguageStandard: .cxx11
+)

--- a/Package.swift
+++ b/Package.swift
@@ -17,17 +17,22 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "tui",
-            path: "source"
+            dependencies: ["glm"],
+            path: "source",
+            publicHeadersPath: "./",
         ),
         .target(
             name: "glm",
-            path: "thirdParty/glm",
-            publicHeadersPath: "thirdParty/glm"
+            path: "thirdParty/glm/glm",
+            publicHeadersPath: "./",
+            cxxSettings: [.headerSearchPath("../")]
         ),
         .executableTarget(
             name: "tui-interpreter",
-            dependencies: ["glm"],
-            path: "interpreter/macos/tui"
+            dependencies: ["tui"],
+            path: "interpreter/",
+            exclude: ["linux/", "windows/"],
+            publicHeadersPath: "./",
         )
     ],
     cxxLanguageStandard: .cxx11

--- a/Package.swift
+++ b/Package.swift
@@ -1,38 +1,34 @@
 // swift-tools-version: 6.1
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
-    name: "tui",
+    name: "Tui",
     products: [
-        // Products define the executables and libraries a package produces, making them visible to other packages.
-        .library(
-            name: "tui",
-            targets: ["tui"]),
+        .library(name: "Tui", targets: ["Tui"]),
         .executable(name: "tui-interpreter", targets: ["tui-interpreter"])
     ],
     targets: [
-        // Targets are the basic building blocks of a package, defining a module or a test suite.
-        // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "tui",
-            dependencies: ["glm"],
+            name: "Tui",
+            dependencies: ["tui-glm"],
             path: "source",
-            publicHeadersPath: "./",
+            publicHeadersPath: "./"
         ),
         .target(
-            name: "glm",
+            name: "tui-glm",
             path: "thirdParty/glm/glm",
-            publicHeadersPath: "./",
-            cxxSettings: [.headerSearchPath("../")]
+            publicHeadersPath: "../glm",
+            cxxSettings: [
+                .headerSearchPath("../")
+            ]
         ),
         .executableTarget(
             name: "tui-interpreter",
-            dependencies: ["tui"],
+            dependencies: ["Tui"],
             path: "interpreter/",
             exclude: ["linux/", "windows/"],
-            publicHeadersPath: "./",
+            publicHeadersPath: "./"
         )
     ],
     cxxLanguageStandard: .cxx11

--- a/source/TuiBuiltInFunctions.cpp
+++ b/source/TuiBuiltInFunctions.cpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 #include <random>
 
-auto rd = std::random_device {};
+std::random_device rd;
 auto rng = std::default_random_engine { rd() };
 
 namespace Tui {
@@ -119,7 +119,7 @@ TuiTable* createRootTable()
 #elif defined (__LINUX__) || defined(__gnu_linux__) || defined(__linux__)
         system("clear");
     //std::cout<< u8"\033[2J\033[1;1H"; //Using ANSI Escape Sequences
-#elif (__APPLE__ && (!TARGET_OS_IPHONE))
+#elif (__APPLE__ && (!defined(TARGET_OS_IPHONE)))
         system("clear");
 #endif
         return nullptr;

--- a/source/TuiFileUtils.cpp
+++ b/source/TuiFileUtils.cpp
@@ -524,7 +524,7 @@ void openFile(std::string filePath)
 {
 #ifdef WIN32
     ShellExecuteW(NULL, L"open", convertUtf8ToWide(filePath).c_str(), NULL, NULL, SW_SHOWDEFAULT);
-#elif (__APPLE__ && (!TARGET_OS_IPHONE))
+#elif (__APPLE__ && (!defined(TARGET_OS_IPHONE)))
     if(filePath.substr(0,4) == "http")
     {
         std::string cmd ="open \"" + filePath + "\"";

--- a/source/TuiRef.cpp
+++ b/source/TuiRef.cpp
@@ -114,7 +114,7 @@ TuiRef* TuiRef::loadBinaryString(const char* inputString, int* currentOffset, Tu
             
             TuiString* stringRef = new TuiString("");
             stringRef->value.resize(stringLength);
-            memcpy(stringRef->value.data(), &inputString[(*currentOffset)], stringLength);
+            memcpy(&stringRef->value, &inputString[(*currentOffset)], stringLength);
             (*currentOffset)+=stringLength;
             
             return stringRef;

--- a/source/TuiRef.cpp
+++ b/source/TuiRef.cpp
@@ -114,7 +114,7 @@ TuiRef* TuiRef::loadBinaryString(const char* inputString, int* currentOffset, Tu
             
             TuiString* stringRef = new TuiString("");
             stringRef->value.resize(stringLength);
-            memcpy(&stringRef->value, &inputString[(*currentOffset)], stringLength);
+            memcpy(&stringRef->value[0], &inputString[(*currentOffset)], stringLength);
             (*currentOffset)+=stringLength;
             
             return stringRef;


### PR DESCRIPTION
Adds SwiftPM support, allowing tui to be easily included in projects using swift package manager.

This also allows the project to be built via `swift build` from the terminal.

"Fixed" a couple of issues that were blocking the build, but I'm honestly not too sure about the consequences of these.