### PR TITLE
Add relative path functionality to require

### DIFF
--- a/source/TuiBuiltInFunctions.cpp
+++ b/source/TuiBuiltInFunctions.cpp
@@ -74,7 +74,7 @@ TuiTable* createRootTable()
     rootTable->setFunction("require", [rootTable](TuiTable* args, TuiRef* existingResult, TuiDebugInfo* callingDebugInfo) -> TuiRef* {
         if(args && args->arrayObjects.size() > 0)
         {
-            return TuiRef::load(Tui::getResourcePath(args->arrayObjects[0]->getStringValue()), rootTable);
+            return TuiRef::load(Tui::getResourcePath(args->arrayObjects[0]->getStringValue(), callingDebugInfo->fileName), rootTable);
         }
         return nullptr;
     });

--- a/source/TuiFileUtils.cpp
+++ b/source/TuiFileUtils.cpp
@@ -98,6 +98,16 @@ std::string getResourcePath(const std::string &appendPath)
     return appendPath;
 }
 
+std::string getResourcePath(const std::string &appendPath, const std::string &filePath)
+{
+    if (fileExistsAtPath(appendPath)) {
+        return appendPath;
+    } else {
+        std::string path = pathByRemovingLastPathComponent(filePath);
+        return pathByAppendingPathComponent(path, appendPath);
+    }
+}
+
 std::vector<std::string> getDirectoryContents(const std::string& dirName)
 {
     std::vector<std::string> result;

--- a/source/TuiFileUtils.h
+++ b/source/TuiFileUtils.h
@@ -14,6 +14,7 @@ std::string getFileContents(const std::string& filename);
 void writeToFile(const std::string& filename, const std::string& data);
 
 std::string getResourcePath(const std::string &appendPath = "");
+std::string getResourcePath(const std::string &appendPath, const std::string &path);
 std::string getSavePath(const std::string &appendPath = "");
 
 std::vector<std::string> getDirectoryContents(const std::string& dirName);

--- a/tests/internalTesting.tui
+++ b/tests/internalTesting.tui
@@ -1,3 +1,3 @@
-#testCommon = require("tests/testCommon.tui")
+#testCommon = require("testCommon.tui")
 #assert = testCommon.assert
 #getLineNumber = debug.getLineNumber

--- a/tests/tests.tui
+++ b/tests/tests.tui
@@ -1,4 +1,4 @@
-testCommon = require("tests/testCommon.tui")
+testCommon = require("testCommon.tui")
 assert = testCommon.assert
 getLineNumber = debug.getLineNumber
 


### PR DESCRIPTION
I think I misunderstood the problem initially, but this should resolve #9 

Pitch: `require` currently only accepts filenames relative to the executable

e.g.
./tui-interpreter
./example.tui
```
require("example.tui")
```

However if the executable is located elsewhere, the file will not be found

e.g.
./tui-interpreter
./tuiFiles/example.tui
```
require("example.tui")
```

In the above example, this can be solved with a relative path
```
require("tuiFiles/example.tui")
```

However it cannot be guaranteed the executable will be run with scripts in subdirectories. One example is a build through Xcode, which will place the executable in `DerivedData/<Project>/Build/Products/...`

With this change, require will also search the path of the currently executing script. Currently, I am getting this from the debugInfo, but I wonder if this is okay or if the executing script path can be fetched in another way.